### PR TITLE
Revert "Instead of using the smem output driver of VLC, we now interact direc…"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ rock_library(video_capture_vlc
     SOURCES VlcCapture.cpp
     HEADERS VlcCapture.h
     DEPS_PKGCONFIG opencv
-    LIBS vlc harfbuzz freetype)
+    LIBS vlc)
 
 Rock_executable(video_capture_vlc_stream Main.cpp
     DEPS video_capture_vlc)

--- a/src/VlcCapture.cpp
+++ b/src/VlcCapture.cpp
@@ -12,11 +12,31 @@ VlcCapture::VlcCapture(std::string url, int input_buffer_ms):buffer_ms(input_buf
 
 	pthread_mutex_init(&imagemutex,NULL);// = PTHREAD_MUTEX_INITIALIZER;
 
-	buffersize = 640*480*4;
-	buffer = (unsigned char*)malloc(buffersize);
+	buffersize = 640*480;
+	buffer = (uint8_t*)malloc(buffersize);
 	imageAvailable = false;
 	width = 0;
 	height = 0;
+
+	//https://gist.github.com/TimSC/4121862
+	sprintf(str_smem_vid_prerender, "--sout-smem-video-prerender-callback=%lld", (long long int)pf_video_prerender_callback);
+	sprintf(str_smem_vid_postrender, "--sout-smem-video-postrender-callback=%lld", (long long int)pf_video_postrender_callback);
+
+	sprintf(str_smem_aud_prerender, "--sout-smem-audio-prerender-callback=%lld", (long long int)pf_audio_prerender_callback);
+	sprintf(str_smem_aud_postrender, "--sout-smem-audio-postrender-callback=%lld", (long long int)pf_audio_postrender_callback);
+
+	sprintf(str_smem_data, "--sout-smem-video-data=%lld", (long long int)this);
+
+	//set vlc transcode options: transcode whatever is open to rgb24 in memory (video only)
+	sprintf(smem_options,"#transcode{vcodec=RV24,acodec=none}:smem{video-prerender-callback=%lld, video-postrender-callback=%lld, video-data=%lld}",(long long int)pf_video_prerender_callback,(long long int)pf_video_postrender_callback,(long long int)this);
+  //	sprintf(smem_options,"#duplicate{dst=display,dst=transcode{vcodec=RV24,acodec=none}:smem{video-prerender-callback=%lld, video-postrender-callback=%lld, video-data=%lld}}",(long long int)pf_video_prerender_callback,(long long int)pf_video_postrender_callback,(long long int)this);
+
+	sprintf(str_netbuf,"--network-caching=%i",buffer_ms);
+
+	//printf("%s\n",str_netbuf);
+
+	//local output
+	//sprintf(smem_options,"#transcode{vcodec=RV24,acodec=none}:duplicate{dst=smem,dst=display}");
 
 	if (url != ""){
 		open(url);
@@ -24,14 +44,23 @@ VlcCapture::VlcCapture(std::string url, int input_buffer_ms):buffer_ms(input_buf
 }
 
 void VlcCapture::open(std::string &url) {
-	std::stringstream networkCachingSS;
-	networkCachingSS << ":network-caching=" << buffer_ms;
-	vlc = libvlc_new(0, 0);
+	const char * const vlc_args[] = {
+		"-I","dummy",
+//		"-vvv",
+		"--ignore-config",
+		str_netbuf,
+//		"--sout-smem-time-sync",
+//		str_smem_vid_prerender,
+//		str_smem_vid_postrender,
+//		str_smem_aud_prerender,
+//		str_smem_aud_postrender,
+//		str_smem_data,
+		"--sout",
+		smem_options
+	};
+	vlc = libvlc_new (sizeof (vlc_args) / sizeof (vlc_args[0]), vlc_args);
 	vlcm = libvlc_media_new_location(vlc, url.c_str());
 	vlcmp = libvlc_media_player_new_from_media (vlcm);
-	libvlc_media_add_option(vlcm, networkCachingSS.str().c_str());
-	libvlc_video_set_callbacks(vlcmp, lock_frame, unlock_frame, 0, this);
-	libvlc_video_set_format_callbacks(vlcmp, format_callback, 0);
 	libvlc_media_release (vlcm);
 	start();
 }
@@ -44,15 +73,21 @@ VlcCapture::~VlcCapture() {
 
 bool VlcCapture::read(cv::Mat& image) {
 	pthread_mutex_lock(&imagemutex);
+	//imagebuf.copyTo(image);
+
 	if (imageAvailable){
-		if (image.rows != height || image.cols != width || image.type() != CV_8UC4){
-			image = cv::Mat(height,width,CV_8UC4);
-		}
-		memcpy(image.data, buffer, buffersize);
+  	if (image.rows != height || image.cols != width || image.type() != CV_8UC3){
+      image = cv::Mat(height,width,CV_8UC3);
+    }
+		memcpy(image.data,buffer,buffersize);
 		imageAvailable = false;
+    //imshow( "image", image );
 		pthread_mutex_unlock(&imagemutex);
+      
 		return true;
-	}
+	}/*else{
+		usleep(10000);
+	}*/
 	pthread_mutex_unlock(&imagemutex);
 	return false;
 }
@@ -65,48 +100,48 @@ void VlcCapture::stop() {
 	libvlc_media_player_stop (vlcmp);
 }
 
-/* user_data is the pointer we pass to `video_set_callbacks()` */
-void* lock_frame(void* user_data, void** planes) {
-	VlcCapture* parent = (VlcCapture*) user_data;
+void pf_video_prerender_callback(void* p_video_data,
+		uint8_t** pp_pixel_buffer, size_t size) {
+
+	VlcCapture* parent = (VlcCapture*)p_video_data;
+
 	pthread_mutex_lock(&parent->imagemutex);
 
-	// /* make '*plane* point to a memory you want the video-data rendered to */
-	*planes= parent->buffer;
+	if (size > parent->buffersize){
+		parent->buffer = (uint8_t*)realloc(parent->buffer,size);
+		parent->buffersize = size;
+	}
+
+	*pp_pixel_buffer = parent->buffer;
+
+}
+
+void pf_video_postrender_callback(void* p_video_data,
+		uint8_t* p_pixel_buffer, int width, int height, int pixel_pitch,
+		size_t size, libvlc_time_t pts) {
+	VlcCapture* parent = (VlcCapture*)p_video_data;
+
+	parent->width = width;
+	parent->height = height;
 	parent->imageAvailable = true;
-	for(int i=0;i<parent->callbacks.size();i++){
-		parent->callbacks[i]->imageCallback();
-	}
-
-	return NULL;
-}
-void unlock_frame(void *user_data, void *picture, void *const *planes) {
-	VlcCapture* parent = (VlcCapture*) user_data;
+        for(int i=0;i<parent->callbacks.size();i++){
+            parent->callbacks[i]->imageCallback();
+        }
 	pthread_mutex_unlock(&parent->imagemutex);
-
-	/* image rendered into (*planes)==parent->buffer; */
 }
 
-unsigned format_callback(void**user_data_ptr, char*chroma, unsigned *width, unsigned *height, unsigned *pitches, unsigned *lines) {
-	VlcCapture* parent =(VlcCapture*)(*user_data_ptr);
-	pthread_mutex_lock(&parent->imagemutex);
+void pf_audio_prerender_callback(void* p_audio_data,
+		uint8_t** pp_pcm_buffer, size_t size) {
 
-	/* set the output format to RGBA */
-	memcpy(chroma, "RV32", sizeof("RV32") - 1); /* 'RV32' is 'RGBA'
-	/* leave dimensions intact, but store them
-	* now's the time to resize parent->buffer to hold that much memory
-	*/
-	parent->width =*width;
-	parent->height=*height;
-	unsigned int pixel_size = 4; /* 4 is the pixel size for RGBA */
-	*pitches=(*width)*pixel_size;
-	*lines=*height;
+	printf("audio size %li\n",size);
+	*pp_pcm_buffer = (uint8_t*)malloc(size);
 
-	size_t newBufferSize = parent->width*parent->height*4;
-	if (newBufferSize > parent->buffersize){
-		parent->buffer = (unsigned char*)realloc(parent->buffer, newBufferSize);
-		parent->buffersize = newBufferSize;
-	}
+}
 
-	pthread_mutex_unlock(&parent->imagemutex);
-	return 1;
+void pf_audio_postrender_callback(void* p_audio_data,
+		uint8_t* p_pcm_buffer, unsigned int channels, unsigned int rate,
+		unsigned int nb_samples, unsigned int bits_per_sample, size_t size,
+		libvlc_time_t pts) {
+	printf("audio post \n");
+	delete p_pcm_buffer;
 }

--- a/src/VlcCapture.h
+++ b/src/VlcCapture.h
@@ -8,20 +8,32 @@
 #ifndef VLCCAPTURE_H_
 #define VLCCAPTURE_H_
 
-// https://stackoverflow.com/questions/32825363/working-with-vlc-smem
+
+//https://wiki.videolan.org/Stream_to_memory_%28smem%29_tutorial/
 
 #include <stdio.h>
 #include <stdint.h>
 #include <string>
-#include <pthread.h>
 
 #include <vlc/vlc.h>
 
+#include <pthread.h>
 #include <opencv2/opencv.hpp>
 
-void* lock_frame(void* user_data, void** planes);
-void unlock_frame(void *user_data, void *picture, void *const *planes);
-unsigned format_callback(void**user_data_ptr, char*chroma, unsigned *width, unsigned *height, unsigned *pitches, unsigned *lines);
+
+/**
+ * lock and set the pointer to image buffer
+ */
+void pf_video_prerender_callback ( void* p_video_data, uint8_t** pp_pixel_buffer, size_t size );
+
+/**
+ * image buffer full, unlock at end
+ */
+void pf_video_postrender_callback ( void* p_video_data, uint8_t* p_pixel_buffer, int width, int height, int pixel_pitch, size_t size, libvlc_time_t pts );
+
+void pf_audio_prerender_callback ( void* p_audio_data, uint8_t** pp_pcm_buffer, size_t size );
+void pf_audio_postrender_callback ( void* p_audio_data, uint8_t* p_pcm_buffer, unsigned int channels, unsigned int rate, unsigned int nb_samples, unsigned int bits_per_sample, size_t size, libvlc_time_t pts );
+
 
 class VlcCaptureConsumer{
     public:
@@ -33,25 +45,60 @@ class VlcCaptureConsumer{
 
 class VlcCapture {
 public:
-	VlcCapture(std::string url = "", int input_buffer_ms = 1000);
+	VlcCapture(std::string url = "", int input_buffer_ms = 10);
 	virtual ~VlcCapture();
 
+
 	void open(std::string &url);
+
+	//bool grab();
+
+	//bool retrieve();
+
 	bool read(cv::Mat &image);
+
 	int start();
+
 	void stop();
 
+
 	pthread_mutex_t imagemutex;
+
+	static pthread_mutex_t callbackmutex;
+
 	int width,height;
-	unsigned char* buffer;
+
+	//cv::Mat imagebuf;
+	uint8_t* buffer;
 	unsigned int buffersize;
+
 	bool imageAvailable;
-	std::vector<VlcCaptureConsumer*> callbacks;
+
+	std::string _url;
+
+
+	void prerender_callback(void* p_video_data, uint8_t** pp_pixel_buffer, size_t size);
+	void postrender_callback(void* p_video_data, uint8_t* p_pixel_buffer, int width, int height, int pixel_pitch, size_t size, libvlc_time_t pts );
+
+        std::vector<VlcCaptureConsumer*> callbacks;
 private:
+
+
+
 	int buffer_ms;
+
+    //options
+    char smem_options[256];
+
+    //callback pointer addess string
+    char str_smem_vid_prerender[100], str_smem_vid_postrender[100];
+    char str_smem_aud_prerender[100], str_smem_aud_postrender[100];
+    char str_smem_data[100],str_netbuf[100];
+
     libvlc_instance_t *vlc;
-	libvlc_media_t *vlcm;
     libvlc_media_player_t *vlcmp;
+    libvlc_media_t *vlcm;
+
 };
 
 #endif /* VLCTOMEMORY_H_ */


### PR DESCRIPTION
Reverts rock-drivers/drivers-video_capture_vlc#3

Two libraries were added as dependencies: harfbuzz and freetype. Please, add them to the manifest and define proper packages in the package set. In the meantime, could you please revert the change? It's breaking many of our builds